### PR TITLE
[META] - Code Ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+#                   DEFAULT
+# This owner will be the default owners for everything in
+# the repo. Unless a later match takes precedence, they will
+# be requested for review when someone opens a pull request.
+
+*                           @jlefebvre55
+
+#                   ADMIN
+# Repo administration code
+
+/.github/                   @utagritech/admins
+LICENSE                     @utagritech/admins
+.gitignore                  @utagritech/admins
+
+#                   DOCUMENTATION
+# TODO: other file types?
+
+/docs/                      @utagritech/documentation-review
+*.tex                       @utagritech/documentation-review
+*.md                        @utagritech/documentation-review
+
+#                   ELECTRONICS
+# Electronics software
+
+/software/PeaPod-Arduino/   @utagritech/electronics
+
+# TODO: Per-deliverable code ownership?


### PR DESCRIPTION
Created CODEOWNERS file with entries for:
- Electronics team (/software/PeaPod-Arduino/)
- Documentation review team (all \*.md, \*.tex, and all in /docs/)
- Admin team (Sensitive repo files)